### PR TITLE
Add waku v2 message wire format

### DIFF
--- a/waku/message/v1/message.proto
+++ b/waku/message/v1/message.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+// 14/WAKU2-MESSAGE rfc: https://rfc.vac.dev/spec/14/
+package waku.message.v1;
+
+message WakuMessage {
+  bytes payload = 1;
+  string content_topic = 2;
+  optional uint32 version = 3;
+  optional sint64 timestamp = 10;
+  optional bool ephemeral = 31;
+}


### PR DESCRIPTION
This PR adds the waku message protocol buffer file to the Waku v2 protocols wire specification repository.

- [x] Add a comment with a link to `14/WAKU2-MESSAGE` RFC.
- [x] Set waku message protobuf file version to `v1`. Note that the folder structure matches the `package` statement in the protobuf file.