### PR TITLE
ci: run workflow only on protobuf file changes

### DIFF
--- a/.github/workflows/ci-ignore.yml
+++ b/.github/workflows/ci-ignore.yml
@@ -1,0 +1,11 @@
+name: ci
+on: 
+  pull_request:
+    ignore-paths:
+      - '**.proto'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,19 @@
 name: ci
-on: pull_request
+on: 
+  pull_request:
+    paths:
+      - '**.proto'
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - uses: bufbuild/buf-setup-action@v1
+
       - uses: bufbuild/buf-lint-action@v1
+
       - uses: bufbuild/buf-breaking-action@v1
         with:
           # The 'main' branch of the GitHub repository that defines the module.


### PR DESCRIPTION
This is a minor optimization in this repo's CI pipeline:

- [x] Only run checks for protobuf file changes