### PR TITLE
feat(waku2-filter): add waku v2 filter protocol v2beta1 wire format

### DIFF
--- a/waku/filter/v2beta1/filter.proto
+++ b/waku/filter/v2beta1/filter.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+// 12/WAKU2-FILTER rfc: https://rfc.vac.dev/spec/12/
+// Protocol identifier: /vac/waku/filter/2.0.0-beta1
+package waku.filter.v2beta1;
+
+import "waku/message/v1/message.proto";
+
+message FilterRequest {
+  message ContentFilter {
+    string content_topic = 1;
+  }
+
+  bool subscribe = 1;
+  string topic = 2;
+  repeated ContentFilter content_filters = 3;
+}
+
+message MessagePush {
+  repeated waku.message.v1.WakuMessage messages = 1;
+}
+
+message FilterRpc {
+  string request_id = 1;
+  optional FilterRequest request = 2;
+  optional MessagePush push = 3;
+}

--- a/waku/store/v2beta4/store.proto
+++ b/waku/store/v2beta4/store.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-import "waku/message/v1/message.proto";
-
 // 13/WAKU2-STORE rfc: https://rfc.vac.dev/spec/13/
 // Protocol identifier: /vac/waku/store/2.0.0-beta4
 package waku.store.v2beta4;
+
+import "waku/message/v1/message.proto";
 
 message Index {
   bytes digest = 1;


### PR DESCRIPTION
This PR aims to add to the repository the [12/WAKU2-FILTER](https://rfc.vac.dev/spec/12/) protocol wire format protobuf files.

- [x] Add the current protocol wire format (`2.0.0-beta1`).
- [x] Add the optional specifiers to the appropriate fields.

