### PR TITLE
feat(waku2-store): add waku v2 store protocol v3 wire format

### DIFF
--- a/waku/store/v3/store.proto
+++ b/waku/store/v3/store.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+// 13/WAKU2-STORE rfc: https://rfc.vac.dev/spec/13/
+// Protocol identifier: /vac/waku/store/3.0.0
+package waku.store.v3;
+
+import "waku/message/v1/message.proto";
+
+
+message HistoryRequest {
+  string request_id = 1;
+  optional string pubsub_topic = 10;
+  repeated string content_topic = 11;
+  optional int64 time_start = 12;
+  optional int64 time_end = 13;
+  // 50 Reserved
+  optional bytes pagination_cursor = 51;
+  optional bool pagination_forward = 52;
+  optional uint64 pagination_limit = 53;
+}
+
+message HistoryResponse {
+  string request_id = 1;
+  optional uint32 status_code = 10;
+  optional string status_desc = 11;
+  repeated waku.message.v1.WakuMessage messages = 20;
+  // 50 Reserved
+  optional bytes pagination_cursor = 51;
+}


### PR DESCRIPTION
The current PR introduces the new Waku store protocol (v3) wire format.

> ⚠️ This is a draft definition. The [13/WAKU2-STORE](https://rfc.vac.dev/spec/13/) RFC update is WIP 