### PR TITLE
feat(WAKU2-MESSAGE): added meta attribute to waku message

### DIFF
--- a/waku/message/v1/message.proto
+++ b/waku/message/v1/message.proto
@@ -8,5 +8,6 @@ message WakuMessage {
   string content_topic = 2;
   optional uint32 version = 3;
   optional sint64 timestamp = 10;
+  optional bytes meta = 11;
   optional bool ephemeral = 31;
 }


### PR DESCRIPTION
As part of the [_Message Unique ID initiative_](https://github.com/waku-org/pm/issues/9), a metadata optional application-specific field has been proposed.

- [x] This PR adds the field to the Waku message protobuf definition.

> **Note**
> This PR depends on the RFC PR: https://github.com/vacp2p/rfc/pull/573