### PR TITLE
feat: improved filter.proto

### DIFF
--- a/waku/filter/v2/filter.proto
+++ b/waku/filter/v2/filter.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+// 12/WAKU2-FILTER rfc: https://rfc.vac.dev/spec/12/
+package waku.filter.v2;
+
+import "waku/message/v1/message.proto";
+
+// Protocol identifier: /vac/waku/filter-subscribe/2.0.0-beta1
+message FilterSubscribeRequest {
+  enum FilterSubscribeType {
+    SUBSCRIBER_PING = 0;
+    SUBSCRIBE = 1;
+    UNSUBSCRIBE = 2;
+    UNSUBSCRIBE_ALL = 3;
+  }
+
+  string request_id = 1;
+  FilterSubscribeType filter_subscribe_type = 2;
+
+  // Filter criteria
+  optional string pubsub_topic = 10;
+  repeated string content_topics = 11;
+}
+
+message FilterSubscribeResponse {
+  string request_id = 1;
+  uint32 status_code = 10;
+  optional string status_desc = 11;
+}
+
+// Protocol identifier: /vac/waku/filter-push/2.0.0-beta1
+message MessagePush {
+  waku.message.v1.WakuMessage waku_message = 1;
+  optional string pubsub_topic = 2;
+}


### PR DESCRIPTION
This PR simply adds the proto files for the new filter protocol as defined in https://rfc.vac.dev/spec/12/