### PR TITLE
chore: deprecate field 2 in `waku_metadata.proto`

### DIFF
--- a/waku/metadata/v1/waku_metadata.proto
+++ b/waku/metadata/v1/waku_metadata.proto
@@ -5,10 +5,21 @@ package waku.metadata.v1;
 
 message WakuMetadataRequest {
   optional uint32 cluster_id = 1;
-  repeated uint32 shards = 2;
+  repeated uint32 shards = 3;
+
+  // Starting from nwaku v0.26, if field 3 contains no data, it will attempt to
+  // decode this field first assuming it's a packed field, and if that fails,
+  // attempt to decode as an unpacked field
+  repeated uint32 shards_deprecated = 2 [deprecated=true, packed=false];
+
 }
 
 message WakuMetadataResponse {
   optional uint32 cluster_id = 1;
-  repeated uint32 shards = 2;
+  repeated uint32 shards = 3;
+
+  // Starting from nwaku v0.26, if field 3 contains no data, it will attempt to
+  // decode this field first assuming it's a packed field, and if that fails,
+  // attempt to decode as an unpacked field
+  repeated uint32 shards_deprecated = 2 [deprecated = true, packed=false];
 }


### PR DESCRIPTION
In this PR i deprecate field 2 for reasons described in https://github.com/waku-org/nwaku/pull/2511 in which the behavior the nwaku differs from the current implementation, and to avoid introducing breaking changes, a new packed field is introduced, while field 2 is marked as not packed which is how nwaku behaves in versions <= 0.25